### PR TITLE
Add async route and API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -177,6 +177,15 @@
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
       "dev": true
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
@@ -691,6 +700,11 @@
         "vary": "~1.1.2"
       }
     },
+    "express-async-handler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.1.3.tgz",
+      "integrity": "sha512-+FlD3SW7LsGPqmCAHHkTMq4vuNULDwjO0NwPzS7UMAwHPyoKfrSlzDJBWEy8BoacxpykPJ6leaWTNN/bJYWgKQ=="
+    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -837,6 +851,24 @@
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "requires": {
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-in": {
@@ -1036,8 +1068,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   "dependencies": {
     "@types/express": "^4.16.0",
     "@types/node": "^10.3.5",
-    "express": "^4.16.3"
+    "axios": "^0.18.0",
+    "express": "^4.16.3",
+    "express-async-handler": "^1.1.3"
   },
   "devDependencies": {
     "husky": "^1.0.0-rc.9",

--- a/src/api/nasa/index.ts
+++ b/src/api/nasa/index.ts
@@ -1,9 +1,17 @@
 import * as express from 'express';
+import * as asyncHandler from 'express-async-handler';
+
+import nasaService from '../../services/nasa/nasa.service';
 
 const router = express.Router();
 
-router.get('/apod', (_, res) => {
-  res.send({ apod: true });
-});
+router.get(
+  '/apod',
+  asyncHandler(async (_, res) => {
+    const apod = await nasaService.getApod();
+
+    res.send({ apod });
+  }),
+);
 
 export = router;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,5 @@
+export default {
+  api: {
+    nasa: 'https://api.nasa.gov',
+  },
+};

--- a/src/services/nasa/nasa.service.ts
+++ b/src/services/nasa/nasa.service.ts
@@ -1,0 +1,20 @@
+import config from '../../config';
+import axios, { AxiosInstance } from 'axios';
+
+export class NasaService {
+  private api: AxiosInstance;
+
+  constructor() {
+    this.api = axios.create({
+      baseURL: config.api.nasa,
+    });
+  }
+
+  public async getApod() {
+    const response = await this.api.get('/planetary/apod?api_key=DEMO_KEY');
+
+    return response.data;
+  }
+}
+
+export default new NasaService();


### PR DESCRIPTION
Used to call `next` in case of failure in `async` routes
```
npm i -S express-async-handler
```

```ts
import * as asyncHandler from 'express-async-handler';

router.get(
  '/apod',
  asyncHandler(async (_, res) => {
    res.send({ data: true });
  }),
);
```